### PR TITLE
fixed typo in WebAPI method name

### DIFF
--- a/config/api/version-1.2.config.php
+++ b/config/api/version-1.2.config.php
@@ -300,12 +300,12 @@ ruleNames: array, a list of rule names that are defined in the system: Function 
                                         )
                                 )
                                 ,
-                                'monitorGetIssuesDetails' => array (
+                                'monitorGetIssueDetails' => array (
                                         'options' => array (
-                                                'route' => 'monitorGetIssuesDetails --issueId= [--limit=]',
+                                                'route' => 'monitorGetIssueDetails --issueId= [--limit=]',
                                                 'defaults' => array (
                                                         'controller' => 'webapi-api-controller',
-                                                        'action' => 'monitorGetIssuesDetails'
+                                                        'action' => 'monitorGetIssueDetails'
                                                 ),
                                         		'group' => 'monitor',
                                         		'info' => array (


### PR DESCRIPTION
the WebAPI method is called monitorGetIssueDetails (not monitorGetIssuesDetails)
