### PR TITLE
Only attach preDispatch listener if target is configured.

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -99,14 +99,16 @@ class Module implements ConfigProviderInterface, AutoloaderProviderInterface,
     {
         $serviceManager = $event->getApplication()->getServiceManager();
         $this->config = $serviceManager->get('config');
-        $eventManager = $event->getApplication()->getEventManager();
-        $eventManager->attach(MvcEvent::EVENT_DISPATCH,
+        if (!empty($this->config['zsapi']['target'])) {
+            $eventManager = $event->getApplication()->getEventManager();
+            $eventManager->attach(MvcEvent::EVENT_DISPATCH,
                 array(
-                        $this,
-                        'preDispatch'
+                    $this,
+                    'preDispatch'
                 ), 100);
-
-        $serviceManager->setService('targetConfig', new ArrayObject($this->config['zsapi']['target']));
+            
+            $serviceManager->setService('targetConfig', new ArrayObject($this->config['zsapi']['target']));
+        }
     }
 
     /**


### PR DESCRIPTION
This makes it easy for developers who are not using the ZendServer to override the zsapi target configuration so that the application can still run.